### PR TITLE
Surface pool connection errors

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -91,7 +91,10 @@ func (cfg *ClusterConfig) CreateSession() (*Session, error) {
 	if len(cfg.Hosts) < 1 {
 		return nil, ErrNoHosts
 	}
-	pool := cfg.ConnPoolType(cfg)
+	pool, e := cfg.ConnPoolType(cfg)
+	if e != nil {
+		return nil, e
+	}
 
 	//Adjust the size of the prepared statements cache to match the latest configuration
 	stmtsLRU.mu.Lock()

--- a/connectionpool.go
+++ b/connectionpool.go
@@ -151,13 +151,12 @@ func NewSimplePool(cfg *ClusterConfig) (ConnectionPool, error) {
 		}
 
 		e := pool.connect(addr)
-		if e == nil {
-			pool.cFillingPool <- 1
-			go pool.fillPool()
-			break
-		} else {
+		if e != nil {
 			return pool, e
 		}
+		pool.cFillingPool <- 1
+		go pool.fillPool()
+		break
 	}
 
 	return pool, e


### PR DESCRIPTION
BC breaking change to NewSimplePool interface. 

Currently NewSimplePool ignores errors that occur when connecting to the cluster and keyspace. If an error occurs, the only error reporting is a log to stderr, the client is allowed to silently continue.  

NewSimplePool should return an error as well as the pool struct because it actually establishes the connection, not just initialises the pool struct. Ignoring this error means that any connection errors with the cluster or keyspace can't be identified properly. 
