### PR TITLE
Surface ErrNotFound Errors on Iterator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,3 +44,4 @@ Ashwin Purohit <purohit@gmail.com>
 Dan Kinder <dkinder.is.me@gmail.com>
 Oliver Beattie <oliver@obeattie.com>
 Justin Corpron <justin@retailnext.com>
+Johanna Cherry <johanna@johannacherry.com>

--- a/session.go
+++ b/session.go
@@ -471,12 +471,10 @@ func (iter *Iter) Close() error {
 
 // checkErrAndNotFound handle error and NotFound in one method.
 func (iter *Iter) checkErrAndNotFound() error {
-	if iter.err != nil {
-		return iter.err
-	} else if len(iter.rows) == 0 {
-		return ErrNotFound
+	if iter.err == nil && len(iter.rows) == 0 {
+		iter.err = ErrNotFound
 	}
-	return nil
+	return iter.err
 }
 
 type nextIter struct {

--- a/session.go
+++ b/session.go
@@ -362,9 +362,6 @@ func (q *Query) MapScan(m map[string]interface{}) error {
 // were selected, ErrNotFound is returned.
 func (q *Query) Scan(dest ...interface{}) error {
 	iter := q.Iter()
-	if err := iter.checkErrAndNotFound(); err != nil {
-		return err
-	}
 	iter.Scan(dest...)
 	return iter.Close()
 }

--- a/session.go
+++ b/session.go
@@ -432,6 +432,7 @@ func (iter *Iter) Columns() []ColumnInfo {
 // end of the result set was reached or if an error occurred. Close should
 // be called afterwards to retrieve any potential errors.
 func (iter *Iter) Scan(dest ...interface{}) bool {
+	iter.checkErrAndNotFound()
 	if iter.err != nil {
 		return false
 	}


### PR DESCRIPTION
When scanning for rows on an `*Iter`, if you get an `ErrNotFound` error, it is not returned or otherwise available in the interface. This patch fixes that problem, so when you call `Iter.Scan()` and get `ErrNotFound` it will return `false` to stop any loop, and store the error in `iter.err` for retrieval later with `Iter.Close()`.